### PR TITLE
[#7] feat: response 포맷 추가

### DIFF
--- a/src/main/java/com/octopus/friends/common/domain/CommonResponse.java
+++ b/src/main/java/com/octopus/friends/common/domain/CommonResponse.java
@@ -1,0 +1,28 @@
+package com.octopus.friends.common.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 패키지명 com.octopus.friends.common.domain
+ * 클래스명 CommonResponse
+ * 클래스설명 공통 response 속성을 제공하는 도메인
+ * 작성일 2022-09-18
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CommonResponse {
+    boolean success;
+    int code;
+    String message;
+
+}

--- a/src/main/java/com/octopus/friends/common/domain/ListResponse.java
+++ b/src/main/java/com/octopus/friends/common/domain/ListResponse.java
@@ -1,0 +1,32 @@
+package com.octopus.friends.common.domain;
+
+import com.octopus.friends.common.domain.enums.Status;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+/**
+ * 패키지명 com.octopus.friends.common.domain
+ * 클래스명 ListReponse
+ * 클래스설명 list데이터 reponse시 값을 반환하는 클래스
+ * 작성일 2022-09-18
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@Setter
+public class ListResponse<T> extends CommonResponse{
+    List<T> dataList;
+
+    public ListResponse(List<T> dataList, Status status){
+        this.dataList = dataList;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+        this.success = true;
+    }
+}

--- a/src/main/java/com/octopus/friends/common/domain/SingleResponse.java
+++ b/src/main/java/com/octopus/friends/common/domain/SingleResponse.java
@@ -1,0 +1,31 @@
+package com.octopus.friends.common.domain;
+
+import com.octopus.friends.common.domain.enums.Status;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 패키지명 com.octopus.friends.common.domain
+ * 클래스명 SingleResponse
+ * 클래스설명 단일데이터 response시 값을 반환하는 클래스
+ * 작성일 2022-09-18
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+public class SingleResponse<T> extends CommonResponse {
+    T data;
+
+    public SingleResponse(T data, Status status){
+        this.data = data;
+        this.success = true;
+        this.code = status.getCode();
+        this.message = status.getMessage();
+    }
+}

--- a/src/main/java/com/octopus/friends/common/domain/enums/Status.java
+++ b/src/main/java/com/octopus/friends/common/domain/enums/Status.java
@@ -1,0 +1,29 @@
+package com.octopus.friends.common.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 패키지명 com.octopus.friends.common.domain.enums
+ * 클래스명 status
+ * 클래스설명 response의 응답코드와 응답메세지에 대한 Enum
+ * 작성일 2022-09-18
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Getter
+@AllArgsConstructor
+public enum Status {
+
+    SUCCESS(200,"성공"),
+    FAIL(-999,"실패"),
+    SUCCESS_JOINED_CHATROOM(200, "채팅방 입장 성공"),
+    SUCCESS_SEARCHED_CHATROOM(200,"채팅방 전체 조회 성공"),
+    SUCCESS_CREATED_CHATROOM(201, "채팅방 생성 성공");
+
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/octopus/friends/common/service/ResponseService.java
+++ b/src/main/java/com/octopus/friends/common/service/ResponseService.java
@@ -1,0 +1,87 @@
+package com.octopus.friends.common.service;
+
+import com.octopus.friends.common.domain.CommonResponse;
+import com.octopus.friends.common.domain.ListResponse;
+import com.octopus.friends.common.domain.SingleResponse;
+import com.octopus.friends.common.domain.enums.Status;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * 패키지명 com.octopus.friends.common.service
+ * 클래스명 ResponseService
+ * 클래스설명
+ * 작성일 2022-09-18
+ *
+ * @author 원지윤
+ * @version 1.0
+ * [수정내용]
+ * 예시) [2022-09-17] 주석추가 - 원지윤
+ */
+@Service
+public class ResponseService {
+    /**
+     * 단일 데이터 response시 사용하는 함수
+     * @param data 응답해줄 단일 데이터 값
+     * @param status 요청에 대한 result code와 message를 담은 Enum
+     * @param <T>
+     * @return
+     */
+    public <T> SingleResponse<T> getSingleResponse(T data, Status status){
+        SingleResponse<T> response = new SingleResponse<>(data,status);
+        return response;
+    }
+
+    /**
+     * 여러 데이터 response시 사용하는 함수
+     * @param dataList 응답해줄 리스트 데이터
+     * @param status 요청에 대한 result code와 message를 담은 Enum
+     * @param <T>
+     * @return
+     */
+    public<T>ListResponse<T> getListResponse(List<T> dataList, Status status){
+        ListResponse<T> response = new ListResponse<>(dataList, status);
+        return response;
+    }
+
+    /**
+     * 무조건 성공 결과만 응답해주는 함수
+     * @return
+     */
+    public CommonResponse getSuccessResponse(){
+        CommonResponse response = new CommonResponse();
+        setSuccessResponse(response);
+        return response;
+    }
+
+    /**
+     * 무조건 실패 결과만 응답해주는 함수
+     * @return
+     */
+    public CommonResponse getFailResponse(){
+        CommonResponse response = new CommonResponse();
+        setFailResponse(response);
+        return response;
+    }
+
+    /**
+     * 성공에 대한 CommonResponse 도메인 설정해주는 함수
+     * @param response
+     */
+    private void setSuccessResponse(CommonResponse response){
+        response.setSuccess(true);
+        response.setCode(Status.SUCCESS.getCode());
+        response.setMessage(Status.SUCCESS.getMessage());
+    }
+
+    /**
+     * 실패에 대한 CommonResponse 도메인 설정해주는 함수
+     * @param response
+     */
+    private void setFailResponse(CommonResponse response){
+        response.setSuccess(false);
+        response.setCode(Status.FAIL.getCode());
+        response.setMessage(Status.FAIL.getMessage());
+    }
+}


### PR DESCRIPTION
response에 대한 포맷을 똑같은 형식으로 맞추기 위해서 파일 추가
`
{
    "success": true,
    "code": 200,
    "message": "",
    "data": {
    }
}
`
위와 같은 형식으로 출력 될 수 있도록 변경common>domain>enums>Status.java
출력이 필요한 code와 message는 [common>domain>enums>Status.java](https://github.com/Don-tOctopus/PlayWithFriend_Server/blob/dev/src/main/java/com/octopus/friends/common/domain/enums/Status.java)에 추가하여 사용